### PR TITLE
Fix code scanning alert no. 2: Missing rate limiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "body-parser": "^1.19.0",
     "dotenv": "^8.2.0",
     "express": "^4.12.4",
-    "mongoose": "^4.2.4"
+    "mongoose": "^4.2.4",
+    "express-rate-limit": "^7.4.1"
   },
   "devDependencies": {},
   "scripts": {

--- a/routes/index.js
+++ b/routes/index.js
@@ -1,12 +1,19 @@
 const router = require('express').Router();
+const rateLimit = require('express-rate-limit');
 
 const { getItems, addItem, deleteItem, updateItem, search } = require('../controllers/itemController');
+
+// set up rate limiter: maximum of 100 requests per 15 minutes
+const searchLimiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 100, // max 100 requests per windowMs
+});
 
 // crud on todo list
 router.get('/', getItems)
 router.post('/', addItem)
 
 // search in the list
-router.post('/search', search)
+router.post('/search', searchLimiter, search)
 
 module.exports = router


### PR DESCRIPTION
Fixes [https://github.com/digiALERT1/Node_JS_1/security/code-scanning/2](https://github.com/digiALERT1/Node_JS_1/security/code-scanning/2)

To fix the problem, we need to introduce rate limiting to the `search` route to prevent potential denial-of-service attacks. The best way to achieve this is by using the `express-rate-limit` middleware. We will set up a rate limiter with a reasonable limit, such as 100 requests per 15 minutes, and apply it to the `search` route.

We will need to:
1. Install the `express-rate-limit` package.
2. Import the `express-rate-limit` package in the `routes/index.js` file.
3. Set up a rate limiter with the desired configuration.
4. Apply the rate limiter to the `search` route.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
